### PR TITLE
feat(customRule): allow reordering rules

### DIFF
--- a/src/lib/customRule.ts
+++ b/src/lib/customRule.ts
@@ -70,22 +70,12 @@ const removeFromAllFiles = async (plugin: IconFolderPlugin, rule: CustomRule): P
 };
 
 /**
- * Really dumb way to sort the custom rules. At the moment, it only sorts the custom rules
- * based on the `localCompare` function.
- * @param plugin Instance of IconFolderPlugin.
- * @returns An array of sorted custom rules.
- */
-const getSortedRules = (plugin: IconFolderPlugin): CustomRule[] => {
-  return plugin.getSettings().rules.sort((a, b) => a.rule.localeCompare(b.rule));
-};
-
-/**
  * Tries to apply all custom rules to all files. This function iterates over all the saved
  * custom rules and calls {@link addToAllFiles}.
  * @param plugin Instance of the IconFolderPlugin.
  */
 const addAll = async (plugin: IconFolderPlugin): Promise<void> => {
-  for (const rule of getSortedRules(plugin)) {
+  for (const rule of plugin.getSettings().rules) {
     await addToAllFiles(plugin, rule);
   }
 };
@@ -174,7 +164,7 @@ const getByPath = (plugin: IconFolderPlugin, path: string): CustomRule | undefin
     return undefined;
   }
 
-  return getSortedRules(plugin).find((rule) => !emoji.isEmoji(rule.icon) && doesExistInPath(rule, path));
+  return plugin.getSettings().rules.find((rule) => !emoji.isEmoji(rule.icon) && doesExistInPath(rule, path));
 };
 
 /**
@@ -199,7 +189,6 @@ const getFiles = (plugin: IconFolderPlugin, rule: CustomRule): TAbstractFile[] =
 export default {
   getFiles,
   doesExistInPath,
-  getSortedRules,
   getByPath,
   removeFromAllFiles,
   add,

--- a/src/lib/iconTabs.ts
+++ b/src/lib/iconTabs.ts
@@ -88,7 +88,7 @@ const add = async (plugin: IconFolderPlugin, file: TFile, options?: AddOptions):
     }
 
     // Add icons to tabs if a custom rule is applicable.
-    for (const rule of customRule.getSortedRules(plugin)) {
+    for (const rule of plugin.getSettings().rules) {
       const isApplicable = await customRule.isApplicable(plugin, rule, file);
       if (isApplicable) {
         dom.setIconForNode(plugin, rule.icon, iconContainer, rule.color);

--- a/src/settings/helper.ts
+++ b/src/settings/helper.ts
@@ -42,7 +42,7 @@ const refreshStyleOfIcons = (plugin: IconFolderPlugin): void => {
 
     // Refreshes the icon style for all custom icon rules, when the color of the rule is
     // not defined.
-    for (const rule of customRule.getSortedRules(plugin)) {
+    for (const rule of plugin.getSettings().rules) {
       const files = customRule.getFiles(plugin, rule);
       for (const file of files) {
         if (rule.color) {

--- a/src/settings/ui/customIconRule.ts
+++ b/src/settings/ui/customIconRule.ts
@@ -134,7 +134,7 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
           await this.plugin.saveIconFolderData();
           this.refreshDisplay();
 
-          customRule.getSortedRules(this.plugin).forEach(async (previousRule) => {
+          this.plugin.getSettings().rules.forEach(async (previousRule) => {
             await customRule.addToAllFiles(this.plugin, previousRule);
             this.updateIconTabs(previousRule, false);
           });
@@ -285,6 +285,55 @@ export default class CustomIconRuleSetting extends IconFolderSetting {
           });
         });
       });
+
+      const index = this.plugin.getSettings().rules.findIndex(
+        (r) => rule.rule === r.rule && rule.color === r.color && rule.icon === r.icon && rule.for === r.for,
+      );
+      
+      settingRuleEl.addExtraButton((btn) => {
+        btn.setDisabled(index === 0);
+        btn.extraSettingsEl.style.cursor = index === 0 ? 'not-allowed' : 'default';
+        btn.extraSettingsEl.style.opacity = index === 0 ? '50%' : '100%';
+        btn.setIcon('arrow-up');
+        btn.setTooltip('Move the custom rule up');
+        btn.onClick(async () => {
+          const previousRule = this.plugin.getSettings().rules[index - 1];
+          this.plugin.getSettings().rules[index - 1] = rule;
+          this.plugin.getSettings().rules[index] = previousRule;
+          await this.plugin.saveIconFolderData();
+          //update DOM
+          await customRule.removeFromAllFiles(this.plugin, oldRule);
+          this.updateIconTabs(rule, true);
+          this.plugin.getSettings().rules.forEach(async (rule) => {
+            await customRule.addToAllFiles(this.plugin, rule);
+            this.updateIconTabs(rule, false);
+          });
+          this.refreshDisplay();
+        });
+      })
+
+      settingRuleEl.addExtraButton((btn) => {
+        btn.setDisabled(index === this.plugin.getSettings().rules.length - 1);
+        btn.extraSettingsEl.style.cursor = index === this.plugin.getSettings().rules.length - 1 ? 'not-allowed' : 'default';
+        btn.extraSettingsEl.style.opacity = index === this.plugin.getSettings().rules.length - 1 ? '50%' : '100%';
+        btn.setIcon('arrow-down');
+        btn.setTooltip('Move the custom rule down');
+        btn.onClick(async () => {
+          // Swap the current rule with the next rule.
+          const nextRule = this.plugin.getSettings().rules[index + 1];
+          this.plugin.getSettings().rules[index + 1] = rule;
+          this.plugin.getSettings().rules[index] = nextRule;
+          //update DOM
+          await customRule.removeFromAllFiles(this.plugin, oldRule);
+          this.updateIconTabs(rule, true);
+          this.plugin.getSettings().rules.forEach(async (rule) => {
+            await customRule.addToAllFiles(this.plugin, rule);
+            this.updateIconTabs(rule, false);
+          });
+          await this.plugin.saveIconFolderData();
+          this.refreshDisplay();
+        });
+      })
     });
   }
 }


### PR DESCRIPTION
See #71 and #226 

Probably not the best way to add this 

> [!NOTE]
> If two rules apply on the same files, the plugin doesn't know which one to use and blink between the icons. Dunno why, to be honest…