### PR TITLE
fix: Deleted file outside of Obsidian don't be clean-up in the plugin settings

### DIFF
--- a/src/iconPackManager.ts
+++ b/src/iconPackManager.ts
@@ -204,10 +204,7 @@ const generateIcon = (iconPackName: string, iconName: string, content: string): 
   }
 
   const svgViewboxMatch = content.match(svgViewboxRegex);
-  let svgViewbox: string = '';
-  if (svgViewboxMatch && svgViewboxMatch.length !== 0) {
-    svgViewbox = svgViewboxMatch[0];
-  }
+  const svgViewbox: string = svgViewboxMatch && svgViewboxMatch.length !== 0 ? svgViewboxMatch[0] : '';
 
   const svgContentMatch = content.match(svgContentRegex);
   if (!svgContentMatch) {
@@ -249,12 +246,10 @@ export const createIconPackPrefix = (iconPackName: string): string => {
 export const loadUsedIcons = async (plugin: Plugin, icons: string[]) => {
   const iconPacks = (await listPath(plugin)).folders.map((iconPack) => iconPack.split('/').pop());
 
-  for (let i = 0; i < icons.length; i++) {
-    const entry = icons[i];
+  for (const entry of icons) {
     if (!entry) {
       continue;
     }
-
     await loadIcon(plugin, iconPacks, entry);
   }
 };
@@ -402,7 +397,7 @@ export const removeIconFromIconPackDirectory = (
 ): Promise<void> => {
   const iconPack = iconPacks.find((iconPack) => iconPack.name === iconPackName);
   // Checks if icon pack is custom-made.
-  if (!iconPack.custom) {
+  if (!iconPack?.custom) {
     return plugin.app.vault.adapter.rmdir(`${path}/${iconPackName}/${iconName}.svg`, true);
   }
 };

--- a/src/iconPacks.ts
+++ b/src/iconPacks.ts
@@ -65,7 +65,7 @@ const iconPacks = {
  */
 export const getExtraPath = (iconPackName: string): string | undefined => {
   const path = Object.values(iconPacks).find((iconPack) => iconPack.name === iconPackName)?.path;
-  return path.length === 0 ? undefined : path;
+  return path?.length === 0 ? undefined : path;
 };
 
 export default iconPacks;

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,7 @@ export default class IconFolderPlugin extends Plugin {
                 iconTabs.update(this, file, iconName);
               };
             }
+            this.cleanUpData();
           });
         };
 
@@ -142,6 +143,7 @@ export default class IconFolderPlugin extends Plugin {
                   if (this.getSettings().iconInTabsEnabled) {
                     iconTabs.add(this, file as TFile, { iconName });
                   }
+                  this.cleanUpData();
                 },
               });
             }
@@ -176,6 +178,7 @@ export default class IconFolderPlugin extends Plugin {
               });
               this.saveInheritanceData(file.path, null);
               removeIconFromIconPack(this, iconData.inheritanceIcon);
+              this.cleanUpData();
             });
           } else {
             item.setTitle('Inherit icon');
@@ -187,6 +190,7 @@ export default class IconFolderPlugin extends Plugin {
                 this.saveInheritanceData(file.path, icon);
                 const iconName = typeof icon === 'string' ? icon : icon.displayName;
                 saveIconToIconPack(this, iconName);
+                this.cleanUpData();
                 inheritance.add(this, file.path, iconName, {
                   onAdd: (file) => {
                     if (this.getSettings().iconInTabsEnabled) {
@@ -209,8 +213,6 @@ export default class IconFolderPlugin extends Plugin {
       this.app.vault.on('delete', (file) => {
         const path = file.path;
         this.removeFolderIcon(path);
-        //cleanUp all other data
-        this.cleanUpData();
       }),
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,6 +100,16 @@ export default class IconFolderPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => this.handleChangeLayout());
     this.registerEvent(this.app.workspace.on('layout-change', () => this.handleChangeLayout()));
 
+    //search deleted files since last session
+    const copyData = { ...this.data };
+    delete copyData.settings;
+    const allPath = Object.keys(copyData);
+    const allFiles = this.app.vault.getFiles();
+    const deletedFiles = allPath.filter((path) => !allFiles.find((file) => file.path === path));
+    for (const path of deletedFiles) {
+      this.removeFolderIcon(path);
+    }
+
     this.registerEvent(
       this.app.workspace.on('file-menu', (menu, file: TFile) => {
         const addIconMenuItem = (item: MenuItem) => {
@@ -268,7 +278,7 @@ export default class IconFolderPlugin extends Plugin {
             if (!isFolder) {
               const folderPath = inheritance.getFolderPathByFilePath(this, file.path);
               const folderInheritance = inheritance.getByPath(this, file.path);
-              const iconName = folderInheritance.inheritanceIcon;
+              const iconName = folderInheritance?.inheritanceIcon;
               dom.removeIconInPath(file.path);
               inheritance.add(this, folderPath, iconName, {
                 file,
@@ -438,7 +448,8 @@ export default class IconFolderPlugin extends Plugin {
       } else {
         iconNameWithPrefix = iconData as string;
       }
-      removeIconFromIconPack(this, iconNameWithPrefix);
+      if (iconNameWithPrefix)
+        removeIconFromIconPack(this, iconNameWithPrefix);
     }
 
     //this.addIconsToSearch();

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,16 +100,6 @@ export default class IconFolderPlugin extends Plugin {
     this.app.workspace.onLayoutReady(() => this.handleChangeLayout());
     this.registerEvent(this.app.workspace.on('layout-change', () => this.handleChangeLayout()));
 
-    //search deleted files since last session
-    const copyData = { ...this.data };
-    delete copyData.settings;
-    const allPath = Object.keys(copyData);
-    const allFiles = this.app.vault.getFiles();
-    const deletedFiles = allPath.filter((path) => !allFiles.find((file) => file.path === path));
-    for (const path of deletedFiles) {
-      this.removeFolderIcon(path);
-    }
-
     this.registerEvent(
       this.app.workspace.on('file-menu', (menu, file: TFile) => {
         const addIconMenuItem = (item: MenuItem) => {
@@ -219,6 +209,8 @@ export default class IconFolderPlugin extends Plugin {
       this.app.vault.on('delete', (file) => {
         const path = file.path;
         this.removeFolderIcon(path);
+        //cleanUp all other data
+        this.cleanUpData();
       }),
     );
 
@@ -560,5 +552,16 @@ export default class IconFolderPlugin extends Plugin {
         }
       }
     }) as unknown as string;
+  }
+
+  cleanUpData(): void {
+    const copyData = { ...this.data };
+    delete copyData.settings;
+    const allPath = Object.keys(copyData);
+    const allFiles = this.app.vault.getFiles();
+    const deletedFiles = allPath.filter((path) => !allFiles.find((file) => file.path === path));
+    for (const path of deletedFiles) {
+      this.removeFolderIcon(path);
+    }
   }
 }


### PR DESCRIPTION
- I refactored a little to convert some variable in inline 
- I fixed some error discovering in #240 

See #240 

My proposition : When the plugin load, check all registered path, and load the path of all Obsidian file. Filter the list, and delete in the settings the path that are removed. 