### PR TITLE
feat: add icons support in notes

### DIFF
--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1866,7 +1866,12 @@ const isEmoji = (str: string): boolean => {
   }
 };
 
+const getShortcode = (key: string): string => {
+  return shortNames[key].replace(/\s/g, '_').replace(/:/g, '').toLowerCase();
+};
+
 export default {
   shortNames,
   isEmoji,
+  getShortcode,
 };

--- a/src/iconsSuggestion.ts
+++ b/src/iconsSuggestion.ts
@@ -1,0 +1,77 @@
+import {
+  App,
+  Editor,
+  EditorPosition,
+  EditorSuggest,
+  EditorSuggestContext,
+  EditorSuggestTriggerInfo,
+} from 'obsidian';
+import { getAllLoadedIconNames } from './iconPackManager';
+import icon from './lib/icon';
+
+export default class SuggestionIcon extends EditorSuggest<string> {
+  constructor(app: App) {
+    super(app);
+  }
+
+  onTrigger(cursor: EditorPosition, editor: Editor): EditorSuggestTriggerInfo {
+    // Isolate shortcode starting position closest to the cursor.
+    const shortcodeStart = editor
+      .getLine(cursor.line)
+      .substring(0, cursor.ch)
+      .lastIndexOf(':');
+
+    // onTrigger needs to return null as soon as possible to save processing performance.
+    if (shortcodeStart == -1) return null;
+
+    const regexOngoingShortcode = editor
+      .getLine(cursor.line)
+      .substring(shortcodeStart, cursor.ch)
+      .match(/^(:)\w+$/g);
+
+    if (regexOngoingShortcode == null) return null;
+
+    const startingIndex = editor
+      .getLine(cursor.line)
+      .indexOf(regexOngoingShortcode[0]);
+
+    return {
+      start: {
+        line: cursor.line,
+        ch: startingIndex,
+      },
+      end: {
+        line: cursor.line,
+        ch: startingIndex + regexOngoingShortcode[0].length,
+      },
+      query: regexOngoingShortcode[0],
+    };
+  }
+
+  getSuggestions(context: EditorSuggestContext): string[] | Promise<string[]> {
+    const queryLowerCase = context.query.substring(1).toLowerCase();
+
+    // Store all icons corresponding to the current query
+    const iconsNameArray = getAllLoadedIconNames()
+      .filter((iconObject) =>
+        iconObject.name.toLowerCase().includes(queryLowerCase),
+      )
+      .map((iconObject) => iconObject.prefix + iconObject.name);
+
+    return iconsNameArray;
+  }
+
+  renderSuggestion(value: string, el: HTMLElement): void {
+    const iconObject = icon.getIconByName(value);
+    el.innerHTML = `${iconObject.svgElement} ${value}`;
+  }
+
+  selectSuggestion(value: string): void {
+    // Save current line to split it
+    const cursor = this.context.editor.getCursor();
+    const line = this.context.editor.getLine(cursor.line);
+    // Replace query with iconNameWithPrefix
+    const updatedLine = line.replace(this.context.query, `:${value}:`);
+    this.context.editor.setLine(cursor.line, updatedLine);
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ import {
 } from '@app/util';
 import config from '@app/config';
 import titleIcon from './lib/icon-title';
+import SuggestionIcon from './iconsSuggestion';
 
 export interface FolderIconObject {
   iconName: string | null;
@@ -349,6 +350,52 @@ export default class IconFolderPlugin extends Plugin {
         this.renameFolder(file.path, oldPath);
       }),
     );
+
+    // post-processing complete :icon: shortcodes in Notes
+    this.registerMarkdownPostProcessor((element) => {
+      // ignore if codeblock
+      const codeElement = element.querySelector('pre > code');
+      if (codeElement) {
+        return;
+      }
+
+      const iconSize: { [key: string]: string } = {
+        H1: '24px',
+        H2: '20px',
+        H3: '18px',
+        H4: '16px',
+      };
+
+      const iconShortcodes = Array.from(
+        element.innerHTML.matchAll(
+          /(:|<:|<a:)((\w{1,64}:\d{17,18})|(\w{1,64}))(:|>)/g,
+        ),
+      );
+
+      for (let index = 0; index < iconShortcodes.length; index++) {
+        const shortcode = iconShortcodes[index][0];
+        const iconName = shortcode.slice(1, shortcode.length - 1);
+        const iconObject = icon.getIconByName(iconName);
+
+        const tagName = element.firstElementChild.tagName;
+        if (iconSize.hasOwnProperty(tagName)) {
+          // Replace first element (DIV html content) with svg element
+          element.firstElementChild.innerHTML =
+            element.firstElementChild.innerHTML
+              .replace(shortcode, iconObject.svgElement)
+              .replace(/(16px)/g, iconSize[tagName]);
+        } else {
+          // Replace shortcode by svg element
+          element.innerHTML = element.innerHTML.replace(
+            shortcode,
+            iconObject.svgElement,
+          );
+        }
+      }
+    });
+
+    // shortcodes auto-completion suggestion in notes
+    this.registerEditorSuggest(new SuggestionIcon(this.app));
 
     this.addSettingTab(new IconFolderSettingsUI(this.app, this));
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,29 +367,30 @@ export default class IconFolderPlugin extends Plugin {
       };
 
       const iconShortcodes = Array.from(
-        element.innerHTML.matchAll(
-          /(:|<:|<a:)((\w{1,64}:\d{17,18})|(\w{1,64}))(:|>)/g,
-        ),
+        element.innerHTML.matchAll(/(:)((\w{1,64}:\d{17,18})|(\w{1,64}))(:)/g),
       );
 
       for (let index = 0; index < iconShortcodes.length; index++) {
         const shortcode = iconShortcodes[index][0];
         const iconName = shortcode.slice(1, shortcode.length - 1);
-        const iconObject = icon.getIconByName(iconName);
 
-        const tagName = element.firstElementChild.tagName;
-        if (iconSize.hasOwnProperty(tagName)) {
-          // Replace first element (DIV html content) with svg element
-          element.firstElementChild.innerHTML =
-            element.firstElementChild.innerHTML
-              .replace(shortcode, iconObject.svgElement)
-              .replace(/(16px)/g, iconSize[tagName]);
-        } else {
-          // Replace shortcode by svg element
-          element.innerHTML = element.innerHTML.replace(
-            shortcode,
-            iconObject.svgElement,
-          );
+        // Find icon and process it if exists
+        const iconObject = icon.getIconByName(iconName);
+        if (iconObject) {
+          const tagName = element.firstElementChild.tagName;
+          if (iconSize.hasOwnProperty(tagName)) {
+            // Replace first element (DIV html content) with svg element
+            element.firstElementChild.innerHTML =
+              element.firstElementChild.innerHTML
+                .replace(shortcode, iconObject.svgElement)
+                .replace(/(16px)/g, iconSize[tagName]);
+          } else {
+            // Replace shortcode by svg element
+            element.innerHTML = element.innerHTML.replace(
+              shortcode,
+              iconObject.svgElement,
+            );
+          }
         }
       }
     });


### PR DESCRIPTION
This PR aims to add support for icons inside Notes content.
Follows up with #148 feature request.

**Two main elements have been added:**

main.ts - Markdown processor for icon shortcodes in notes with no performance impact
- Registering a MarkdownPostProcessor according to Obsidian API implementation.
- Allows to post process icons shortcodes like `:RiHeartsFill:` when they are found in Notes.
- Icons in Headers are dynamically attributed a fitting width and height.
- Code is making sure data-header param is not affected by the shortcodes post process.
- Codeblocks are ignored during post process.
- Colors (for example added with Editing Toolbar plugin) are supported thanks to the `fill:"currentColor"` in the svg tag.
- Processing in itself works by replacing shortcodes with the icon svgElement found with `icon.getIconByName()`.
- Tested with 100 different icons on a note and no performance impact was seen in execution time when switching mode (1ms).

iconSuggestion.ts - EditorSuggest for icons autocompletion
- Isolating icons shortcode that have begun behind the cursor.
- Offering autocompletion as the user types, with an EditorSuggest and an elegant list of the SVG icon and their full name.
- Populating aucompletion list dynamically with `getAllLoadedIconNames()` from `iconPackManager.ts`.
- Selection triggers a replacement of the query into the full icon name with prefix.
- Suggestion can be ignored and user can keep typing.

All modifications are mobile proof and works on mobile and tablet devices.

Let me know if you have any question or idea to improve!

![Iconize - Inline icons in Edit Mode](https://github.com/FlorianWoelki/obsidian-iconize/assets/65596181/af883c04-5a83-43b2-b3b3-142c9533e72e)

![Iconize - Inline icons in Read Mode](https://github.com/FlorianWoelki/obsidian-iconize/assets/65596181/7815a562-733d-4186-af05-a1b4bffe5088)

![Iconize - Autocompletion](https://github.com/FlorianWoelki/obsidian-iconize/assets/65596181/3b7a1d68-5082-4cb8-b4fb-0898a2650d32)
