### PR TITLE
feat(iconPack): add Octicons

### DIFF
--- a/src/icon-packs.ts
+++ b/src/icon-packs.ts
@@ -95,6 +95,14 @@ const iconPacks = {
     downloadLink:
       'https://github.com/feathericons/feather/archive/refs/tags/v4.29.1.zip',
   },
+  /** @source https://github.com/primer/octicons */
+  octicons: {
+    name: 'octicons',
+    displayName: 'Octicons',
+    path: 'octicons-19.8.0/icons/',
+    downloadLink:
+      'https://github.com/primer/octicons/archive/refs/tags/v19.8.0.zip',
+  },
 } as { [key: string]: IconPack };
 
 /**


### PR DESCRIPTION
Adds the MIT licensed Octicons icon set used by GitHub via GitHub release.


On a side note: thank you for this excellent plug-in 😄 