### PR TITLE
Update version for Lucide icon pack to 0.343.0

### DIFF
--- a/src/icon-packs.ts
+++ b/src/icon-packs.ts
@@ -54,7 +54,7 @@ const iconPacks = {
     displayName: 'Lucide',
     path: '',
     downloadLink:
-      'https://github.com/lucide-icons/lucide/releases/download/0.314.0/lucide-icons-0.314.0.zip',
+      'https://github.com/lucide-icons/lucide/releases/download/0.343.0/lucide-icons-0.343.0.zip',
   },
   tablerIcons: {
     name: 'tabler-icons',


### PR DESCRIPTION
Tested the link and the zip downloads fine and has icons in it.
- Release: [0.343.0](https://github.com/lucide-icons/lucide/releases/tag/0.343.0)