### PR TITLE
Disable custom icon-packs forced prefix capitalization

### DIFF
--- a/src/icon-pack-manager.ts
+++ b/src/icon-pack-manager.ts
@@ -306,16 +306,16 @@ const generateIcon = (
 export const createIconPackPrefix = (iconPackName: string): string => {
   if (iconPackName.includes('-')) {
     const splitted = iconPackName.split('-');
-    let result = splitted[0].charAt(0).toUpperCase();
+    let result = splitted[0].charAt(0);
     for (let i = 1; i < splitted.length; i++) {
-      result += splitted[i].charAt(0).toLowerCase();
+      result += splitted[i].charAt(0);
     }
 
     return result;
   }
 
   return (
-    iconPackName.charAt(0).toUpperCase() + iconPackName.charAt(1).toLowerCase()
+    iconPackName.charAt(0) + iconPackName.charAt(1)
   );
 };
 


### PR DESCRIPTION
This allows users to determine if their prefixes are capitalized or not. With current functionality, the plugin takes the first two letters and sets the first letter to upper case and the second letter to lowercase (OR if the icon-pack name contains a dash (`-`), it will take the first letter from the text before the dash, and the first letter from the text after the dash, and capitalize those two letters in the same manner. This change will allow users to determine the capitalization by naming their icon packs accordingly.