### PR TITLE
fix bug where empty tabs are opened when opening file from within pinned tab

### DIFF
--- a/src/editor/live-preview/state.ts
+++ b/src/editor/live-preview/state.ts
@@ -10,7 +10,6 @@ import {
 } from '@codemirror/state';
 import IconFolderPlugin from '@app/main';
 import emoji from '@app/emoji';
-import { ExplorerViewState } from '@app/@types/obsidian';
 
 export type PositionField = StateField<RangeSet<IconPosition>>;
 
@@ -55,13 +54,18 @@ export const buildPositionField = (plugin: IconFolderPlugin) => {
     excludeTo: number,
     updateRange: UpdateRangeFunc,
   ): void => {
-    const isSourceMode = (
-      plugin.app.workspace.getLeaf().getViewState() as ExplorerViewState
-    )?.state?.source;
+    let isSourceMode = false;
+    // Iterate over all leaves to check if any is in source mode
+    plugin.app.workspace.iterateAllLeaves((leaf) => {
+      if (!isSourceMode && leaf.view.getViewType() === 'markdown') {
+        if (leaf.getViewState().state?.source) {
+          isSourceMode = true;
+        }
+      }
+    });
     if (isSourceMode) {
       return;
     }
-
     const text = state.doc.sliceString(0, state.doc.length);
     const identifier = plugin.getSettings().iconIdentifier;
     const regex = new RegExp(

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -2,7 +2,7 @@ import twemoji from 'twemoji';
 import { EmojiStyle } from './settings/data';
 
 const regex =
-  /(\p{Emoji}|\p{Emoji_Presentation}|\p{Emoji_Modifier}|\p{Emoji_Modifier_Base}|\p{Emoji_Component}|\p{Extended_Pictographic})/gu;
+  /(?!#)(\p{Emoji}|\p{Emoji_Presentation}|\p{Emoji_Modifier}|\p{Emoji_Modifier_Base}|\p{Emoji_Component}|\p{Extended_Pictographic})/gu;
 
 const shortNames: Record<string, string> = {
   '😀': 'grinning face',


### PR DESCRIPTION
Fixes #430 wherein opening a file when you are currently viewing a pinned tab causes empty tabs to open in addition to the file selected.