### PR TITLE
feat(ui): add setting to refresh icons from frontmatter

### DIFF
--- a/src/settings/ui/frontmatterOptions.ts
+++ b/src/settings/ui/frontmatterOptions.ts
@@ -114,9 +114,9 @@ export default class FrontmatterOptions extends IconFolderSetting {
             }
 
             if (typeof iconName !== 'string') {
-              const message = `[${config.PLUGIN_NAME}]\n${file.path}\nFrontmatter property type \`${frontmatterIconKey}\` has to be of type \`text\`.`;
+              const message = `${file.path}\nFrontmatter property type \`${frontmatterIconKey}\` has to be of type \`text\`.`;
               logger.warn(message);
-              new Notice(message);
+              new Notice(`[${config.PLUGIN_NAME}]\n${message}`);
               continue;
             }
 
@@ -128,9 +128,9 @@ export default class FrontmatterOptions extends IconFolderSetting {
             }
 
             if (typeof iconColor !== 'string') {
-              const message = `[${config.PLUGIN_NAME}]\n${file.path}\nFrontmatter property type \`${frontmatterIconColorKey}\` has to be of type \`text\`.`;
+              const message = `${file.path}\nFrontmatter property type \`${frontmatterIconColorKey}\` has to be of type \`text\`.`;
               logger.warn(message);
-              new Notice(message);
+              new Notice(`[${config.PLUGIN_NAME}]\n${message}`);
               continue;
             }
 

--- a/src/settings/ui/frontmatterOptions.ts
+++ b/src/settings/ui/frontmatterOptions.ts
@@ -1,6 +1,9 @@
 import { Setting, TextComponent } from 'obsidian';
 import IconFolderSetting from './iconFolderSetting';
 import { Notice } from 'obsidian';
+import config from '@app/config';
+import { isHexadecimal, stringToHex } from '@app/util';
+import { logger } from '@app/lib/logger';
 
 export default class FrontmatterOptions extends IconFolderSetting {
   private iconFieldNameTextComp: TextComponent;
@@ -71,6 +74,75 @@ export default class FrontmatterOptions extends IconFolderSetting {
           this.plugin.getSettings().iconColorInFrontmatterFieldName = newValue;
           await this.plugin.saveIconFolderData();
           new Notice('...saved successfully');
+        });
+      });
+
+    new Setting(this.containerEl)
+      .setName('Refresh icons from frontmatter')
+      .setDesc(
+        'Sets the icon and color for each note in the vault based on the frontmatter properties. WARNING: This will change any manually set icons to the one defined in the frontmatter. IF A NOTE HAS NO FRONTMATTER, THE CURRENT ICON WILL BE REMOVED. Please restart Obsidian after this completes to see the changes.',
+      )
+      .addButton((btn) => {
+        btn.setButtonText('Refresh').onClick(async () => {
+          if (!this.plugin.getSettings().iconInFrontmatterEnabled) {
+            new Notice(
+              `[${config.PLUGIN_NAME}] Please enable "Use icon in frontmatter".`,
+            );
+            return;
+          }
+
+          new Notice(
+            `[${config.PLUGIN_NAME}] Refreshing icons from frontmatter, please wait...`,
+          );
+
+          const files = this.plugin.app.vault.getMarkdownFiles();
+
+          for (const file of files) {
+            const fileCache = this.plugin.app.metadataCache.getFileCache(file);
+
+            const frontmatterIconKey =
+              this.plugin.getSettings().iconInFrontmatterFieldName;
+            const frontmatterIconColorKey =
+              this.plugin.getSettings().iconColorInFrontmatterFieldName;
+
+            const iconName = fileCache.frontmatter?.[frontmatterIconKey];
+            let iconColor = fileCache.frontmatter?.[frontmatterIconColorKey];
+
+            if (!iconName) {
+              await this.plugin.removeFolderIcon(file.path);
+              continue;
+            }
+
+            if (typeof iconName !== 'string') {
+              const message = `[${config.PLUGIN_NAME}]\n${file.path}\nFrontmatter property type \`${frontmatterIconKey}\` has to be of type \`text\`.`;
+              logger.warn(message);
+              new Notice(message);
+              continue;
+            }
+
+            this.plugin.addFolderIcon(file.path, iconName);
+
+            if (!iconColor) {
+              await this.plugin.removeIconColor(file.path);
+              continue;
+            }
+
+            if (typeof iconColor !== 'string') {
+              const message = `[${config.PLUGIN_NAME}]\n${file.path}\nFrontmatter property type \`${frontmatterIconColorKey}\` has to be of type \`text\`.`;
+              logger.warn(message);
+              new Notice(message);
+              continue;
+            }
+
+            iconColor = isHexadecimal(iconColor)
+              ? stringToHex(iconColor)
+              : iconColor;
+
+            this.plugin.addIconColor(file.path, iconColor);
+          }
+          new Notice(
+            `[${config.PLUGIN_NAME}] Refreshed icons from frontmatter. Please restart Obsidian to see the changes.`,
+          );
         });
       });
   }


### PR DESCRIPTION
Closes #423 

Currently, if your icons are defined in frontmatter, there's no easy way to get all your icons back if you reinstall the plugin. I added a button in the settings which allows for a manual refresh of the saved icons based on the frontmatter properties.

After it runs, users must restart Obsidian to see the changes because this intentionally does not do anything with the DOM to keep it fast and simple.