### PR TITLE
Fix #543 (icon display in callout with codeblocks)

### DIFF
--- a/src/editor/markdown-processors/icon-in-text.ts
+++ b/src/editor/markdown-processors/icon-in-text.ts
@@ -81,7 +81,8 @@ export const processIconInTextMarkdown = (
 ) => {
   // Ignore if codeblock
   const codeElement = element.querySelector('pre > code');
-  if (codeElement) {
+  const callOut = element.querySelector('.callout');
+  if (codeElement && !callOut) {
     return;
   }
 


### PR DESCRIPTION
Fix #543

Adding a simple condition to not ignore callouts containing codeblocks in the text processing of markdown.

![fix](https://github.com/user-attachments/assets/84d1867e-b265-49ef-bf04-fa033469187f)