### PR TITLE
Check itemDoms to prevent crash during initialization on Obsidian 1.7.4

### DIFF
--- a/src/internal-plugins/bookmark.ts
+++ b/src/internal-plugins/bookmark.ts
@@ -97,6 +97,10 @@ export default class BookmarkInternalPlugin extends InternalPluginInjector {
       item: BookmarkItem,
       itemDoms: WeakMap<BookmarkItem, BookmarkItemValue>,
     ): void => {
+      if (!itemDoms) {
+        return;
+      }
+      
       const lookupItem = itemDoms.get(item);
       if (!lookupItem) {
         return;


### PR DESCRIPTION
This is probably not the right fix, but it prevents crashing during initialization on Obsidian 1.7.4.