### PR TITLE
Fixed lagginess for notes with many icons

### DIFF
--- a/src/lib/util/text.ts
+++ b/src/lib/util/text.ts
@@ -1,10 +1,23 @@
-const calculateFontTextSize = (): number => {
+// Cache for font size
+let cachedFontSize: number | null  = null;
+let fontSizeCacheTime: number = 0;
+
+const calculateFontTextSize = () => {
+  // get cached font size if available
+  const now = Date.now();
+  if (cachedFontSize !== null && now - fontSizeCacheTime < 2000) {
+    return cachedFontSize;
+  }
+
   let fontSize = parseFloat(
     getComputedStyle(document.body).getPropertyValue('--font-text-size') ?? '0',
   );
   if (!fontSize) {
     fontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
   }
+  // set font size cache
+  cachedFontSize = fontSize;
+  fontSizeCacheTime = now;
   return fontSize;
 };
 


### PR DESCRIPTION
Added a small cache for font size that expires after 2 seconds. if many re-renders of inline icons happen at once (every icon in every internal link onscreen gets rerendered in the dom whenever you type), it won't spend a lot of time in this method any more. 

I tried for a while to get at the root of the problem which is that it re-renders all the icons onscreen everytime you type anything, but wasn't able to get that to work well, so went with this simpler fix.

Fixes issue #602 

See before/after examples:

BEFORE:

https://github.com/user-attachments/assets/f8f9e74d-9684-463f-83f7-3b1500b9c689


AFTER:

https://github.com/user-attachments/assets/792e340d-c3d7-47f3-a126-b85559220342

