### PR TITLE
Fixes duplication of imported custom icons

### DIFF
--- a/src/icon-pack-manager.ts
+++ b/src/icon-pack-manager.ts
@@ -508,15 +508,17 @@ export const initIconPacks = async (plugin: IconizePlugin): Promise<void> => {
     }
 
     const prefix = createIconPackPrefix(folderName);
-    iconPacks.push({
-      name: folderName,
-      icons: loadedIcons,
-      prefix,
-      custom: true,
-    });
-    logger.info(
-      `Loaded icon pack '${folderName}' (amount of icons: ${loadedIcons.length})`,
-    );
+    if (!iconPacks.some(iconPack => iconPack.name === folderName)) {
+      iconPacks.push({
+          name: folderName,
+          icons: loadedIcons,
+          prefix,
+          custom: true,
+      });
+      logger.info(
+        `Loaded icon pack '${folderName}' (amount of icons: ${loadedIcons.length})`,
+      );
+    }
   }
 
   // Extract all files from the zip files.
@@ -531,15 +533,17 @@ export const initIconPacks = async (plugin: IconizePlugin): Promise<void> => {
       continue;
     }
 
-    iconPacks.push({
-      name: zipFile,
-      icons: loadedIcons,
-      prefix,
-      custom: false,
-    });
-    logger.info(
-      `Loaded icon pack '${zipFile}' (amount of icons: ${loadedIcons.length})`,
-    );
+    if (!iconPacks.some(iconPack => iconPack.name === zipFile)) {
+      iconPacks.push({
+          name: zipFile,
+          icons: loadedIcons,
+          prefix,
+          custom: false,
+      });
+      logger.info(
+        `Loaded icon pack '${zipFile}' (amount of icons: ${loadedIcons.length})`,
+      );
+    }
   }
 };
 


### PR DESCRIPTION
Fix suggestion made by @FlameStack, this fix worked for me and i wanted to share with other people needing help here
Verifies if icon set already loaded

Change suggestion:
 https://github.com/FlorianWoelki/obsidian-iconize/issues/314#issuecomment-2093941254

Issue:
- https://github.com/FlorianWoelki/obsidian-iconize/issues/370
- https://github.com/FlorianWoelki/obsidian-iconize/issues/314

Maybe related?
- https://github.com/FlorianWoelki/obsidian-iconize/issues/420