### PR TITLE
Avoid edge cases

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -538,7 +538,7 @@ export default class IconizePlugin extends Plugin {
           }
 
           for (const openedFile of getAllOpenedFiles(this)) {
-            if (openedFile.path !== file.path) {
+            if (!file || !openedFile || openedFile.path !== file.path) {
               continue;
             }
 


### PR DESCRIPTION
Handle some cases when new tab has no `file` (Like the HomeTab Plugin)