### PR TITLE
CSS: Avoid inline title wrapper side scrolling on mobile

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,6 @@
 .iconize-inline-title-wrapper {
   width: var(--line-width);
+  max-width: 100%;
   margin-inline: var(--content-margin);
 }
 


### PR DESCRIPTION
The --line-width can be wider than the mobile display (or a narrow desktop display) and would cause sidescrolling.