### PR TITLE
Fix title wrapper margins

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,6 @@
 .iconize-inline-title-wrapper {
   width: var(--line-width);
-  max-width: 100%;
+  max-width: var(--max-width);
   margin-inline: var(--content-margin);
 }
 


### PR DESCRIPTION
My #629 fixed side scrolling, but it turns out a 100% max-width also means no margins on narrow displays. This fixes both issues.