### PR TITLE
fix: fix certain characters make Obsidian freeze

### DIFF
--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1879,7 +1879,7 @@ const parseEmoji = (
 ): string | null => {
   switch (style) {
     case 'twemoji':
-      return twemoji.parse(str, {
+      let parsedStr = twemoji.parse(str, {
         folder: 'svg',
         ext: '.svg',
         attributes: () => ({
@@ -1887,6 +1887,9 @@ const parseEmoji = (
           height: `${size}px`,
         }),
       });
+      // Some characters like "©" are treated as non-emoji, and
+      // isEmoji method passes those. Use below expression to anticipate that.
+      return parsedStr === str ? null : parsedStr;
     case 'native':
       return str;
     default:


### PR DESCRIPTION
This issue happens when certain characters like "©" are parsed by twemoji.parse() as non-emoji, while isEmoji() passes those. Detail explanation is in the code comments. Fix #641