### PR TITLE
fix wrong Country emoji name

### DIFF
--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1789,7 +1789,7 @@ const shortNames: Record<string, string> = {
   '🇵🇲': 'flag: St. Pierre & Miquelon',
   '🇵🇳': 'flag: Pitcairn Islands',
   '🇵🇷': 'flag: Puerto Rico',
-  '🇵🇸': 'flag: Palestinian Territories',
+  '🇵🇸': 'flag: Palestine',
   '🇵🇹': 'flag: Portugal',
   '🇵🇼': 'flag: Palau',
   '🇵🇾': 'flag: Paraguay',


### PR DESCRIPTION
Accuracy and Common Usage: The term "Palestine" is widely used in everyday language, international media, and by major platforms (e.g., Apple, WhatsApp, and Twitter) to refer to the region represented by this emoji. Updating the label improves alignment with real-world usage and user expectations.

Clarity and Simplicity: "Palestine" is a more concise and recognizable term than "Palestinian Territories," reducing confusion—especially in user interfaces that display emoji names.

Consistency: This aligns the naming convention with other flag entries in the list, which use familiar and commonly accepted country or region names

Inclusivity and Representation: Using "Palestine" acknowledges the identity of millions of users who search for or refer to this flag using this name. It improves the inclusivity and cultural respect in the app’s UX.